### PR TITLE
Include boost/filesystem/directory.hpp

### DIFF
--- a/src/web/FileUtils.C
+++ b/src/web/FileUtils.C
@@ -6,6 +6,7 @@
 
 #include "web/FileUtils.h"
 
+#include <boost/filesystem/directory.hpp>
 #include <boost/filesystem/operations.hpp>
 
 #include "web/WebUtils.h"


### PR DESCRIPTION
As of Boost 1.85, boost/filesystem/operations.hpp no longer implicitly includes boost/filesystem/directory.hpp